### PR TITLE
Fix NVML interfacing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,6 @@ stderrlog = "0.4.3"
 tui = "0.9.1"
 sysinfo = "0.10.3"
 battery = {version = "0.7.5", optional = true}
-nvml-wrapper = {version = "0.5.0", optional = true}
+nvml-wrapper = {version = "0.7.0", optional = true}
 #phf = { version = "0.8.0", optional = true, features = ["macros"]}
 

--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,7 @@ fn main() -> std::io::Result<()> {
                 Err(_) => return Err(std::io::Error::new(std::io::ErrorKind::Other, "Could not find NVIDIA Driver verion"))
             };
             println!("cargo:rustc-env=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/nvidia-{}/libnvidia-ml.so", nvidia_driver_version);
+            println!("cargo:rustc-env=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu");
 
             let home_dir = match dirs::home_dir() {
                 Some(p) => format!("{}", p.display()),

--- a/src/rtop/app.rs
+++ b/src/rtop/app.rs
@@ -265,16 +265,16 @@ impl <'a> App<'a> {
     fn si_prefix(num: u64) -> (u64, String) {
         let n = num as f64;
         if n == 0.0 {
-            return (1 as u64, String::from(""));
+            return (1_u64, String::from(""));
         }
         match n.log(10.0) as u64 {
-            0 | 1 | 2 => ((10 as u64).pow(0), String::from("")),
-            3 | 4 | 5 => ((10 as u64).pow(3), String::from("K")),
-            6 | 7 | 8 => ((10 as u64).pow(6), String::from("M")),
-            9 | 10 | 11 => ((10 as u64).pow(9), String::from("G")),
-            12 | 13 | 14 => ((10 as u64).pow(12), String::from("T")),
-            15 | 16 | 17 => ((10 as u64).pow(15), String::from("P")),
-            _ => ((10 as u64).pow(18), String::from("E")),
+            0 | 1 | 2 => (10_u64.pow(0), String::from("")),
+            3 | 4 | 5 => (10_u64.pow(3), String::from("K")),
+            6 | 7 | 8 => (10_u64.pow(6), String::from("M")),
+            9 | 10 | 11 => (10_u64.pow(9), String::from("G")),
+            12 | 13 | 14 => (10_u64.pow(12), String::from("T")),
+            15 | 16 | 17 => (10_u64.pow(15), String::from("P")),
+            _ => (10_u64.pow(18), String::from("E")),
         }
     }
 }

--- a/src/rtop/appdatastreams.rs
+++ b/src/rtop/appdatastreams.rs
@@ -6,29 +6,29 @@ use nvml_wrapper::NVML;
 use battery::Manager;
 
 use crate::rtop::error::Error;
-use crate::rtop::datastreams::{SysDataStream, DiskMonitor, MemoryMonitor, 
+use crate::rtop::datastreams::{SysDataStream, DiskMonitor, MemoryMonitor,
                               CPUMonitor, NetworkMonitor, ProcessMonitor};
 
 #[cfg(feature = "battery-monitor")]
 use crate::rtop::datastreams::{BatteryDataStream, BatteryMonitor};
-#[cfg(feature = "gpu-monitor")] 
+#[cfg(feature = "gpu-monitor")]
 use crate::rtop::datastreams::{GPUDataStream, GPUMonitor};
 
 pub struct AppDataStreams {
     pub disk_info: DiskMonitor,
     pub cpu_info: CPUMonitor,
-    #[cfg(feature = "gpu-monitor")] 
+    #[cfg(feature = "gpu-monitor")]
     pub gpu_info: GPUMonitor,
     pub net_info: NetworkMonitor,
     pub mem_info: MemoryMonitor,
     pub process_info: ProcessMonitor,
-    #[cfg(feature = "battery-monitor")] 
+    #[cfg(feature = "battery-monitor")]
     pub battery_info: BatteryMonitor,
     pub sys_info_src: SysInfoSystem,
     #[cfg(feature = "gpu-monitor")]
     pub gpu_info_src: NVML,
-    #[cfg(feature = "battery-monitor")] 
-    pub battery_info_src: Manager, 
+    #[cfg(feature = "battery-monitor")]
+    pub battery_info_src: Manager,
 }
 
 impl <'a> AppDataStreams {

--- a/src/rtop/error.rs
+++ b/src/rtop/error.rs
@@ -3,9 +3,9 @@ use std::error;
 use std::fmt;
 
 #[cfg(feature = "gpu-monitor")]
-use nvml_wrapper::error::Error as nvmlError; 
+use nvml_wrapper::error::NvmlError as nvmlError;
 #[cfg(feature = "battery-monitor")]
-use battery::errors::Error as batteryError; 
+use battery::errors::Error as batteryError;
 
 
 #[derive(Debug)]
@@ -15,7 +15,7 @@ pub enum Error {
     NVMLError(nvmlError),
     #[cfg(feature = "battery-monitor")]
     BatteryMonitorError(batteryError),
-} 
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -24,7 +24,7 @@ impl fmt::Display for Error {
             #[cfg(feature = "gpu-monitor")]
             Error::NVMLError(ref err) => write!(f, "NVML error: {}", err),
             #[cfg(feature = "battery-monitor")]
-            Error::BatteryMonitorError(ref err) => write!(f, "Battery Monitor error: {}", err), 
+            Error::BatteryMonitorError(ref err) => write!(f, "Battery Monitor error: {}", err),
         }
     }
 }

--- a/src/rtop/ui/panels/gpu/deviceinfo.rs
+++ b/src/rtop/ui/panels/gpu/deviceinfo.rs
@@ -12,15 +12,18 @@ pub fn device_panel<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
         ["Device", "Name", "Bus ID", "Memory", "VBIOS", "PCIe Connection", "Max SM Clock", "Max Memory Clock", "Power Limit"].iter(),
         app.datastreams.gpu_info.device_info.iter().map(|(_, gpu)| {
             let style = &default_style;
-            Row::StyledData(vec![gpu.id.to_string(), 
-                                 gpu.name.clone(), 
-                                 gpu.bus_id.clone(), 
-                                 bytes_to_gb(gpu.max_memory), 
+            Row::StyledData(vec![gpu.id.to_string(),
+                                 gpu.name.clone(),
+                                 gpu.bus_id.clone(),
+                                 bytes_to_gb(gpu.max_memory),
                                  gpu.vbios.clone(),
                                  format!("{}x", gpu.num_pcie_lanes),
                                  format!("{} MHz", gpu.max_sm_clock),
                                  format!("{} MHz", gpu.max_mem_clock),
-                                 format!("{} W", gpu.power_limit),
+                                 match gpu.power_limit {
+                                    0 => "Unknown".to_string(),
+                                    _ => format!("{} W", gpu.power_limit),
+                                 },
             ].into_iter(), *style)
         }),
     ).block(Block::default().title("Devices").borders(Borders::ALL))
@@ -37,9 +40,9 @@ pub fn device_panel<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
             Constraint::Length(20),
         ]);
 
-    f.render_widget(device_table, area);  
+    f.render_widget(device_table, area);
 }
 
 fn bytes_to_gb(mem: u64) -> String {
-    format!("{:.0} GB", (mem / 1000000000)) 
+    format!("{:.0} GB", (mem / 1000000000))
 }

--- a/src/rtop/ui/panels/system/cpuusage.rs
+++ b/src/rtop/ui/panels/system/cpuusage.rs
@@ -44,7 +44,7 @@ pub fn cpu_usage_history_panel<B: Backend>(f: &mut Frame<B>, app: &App, area: Re
                 .bounds([0.0, 1.0])
                 .labels(&["0", "20", "40", "60", "80", "100"]),
         )
-        .datasets(&datasets);
+        .datasets(datasets);
 
     f.render_widget(cpu_usage, area);
 }


### PR DESCRIPTION
Laptop GPUs do not expose power targets. This was causing the reporting initialization to fail. Now this is handled so laptops will just report Unknown. 

Fixes: #14 